### PR TITLE
Make evalute and hence fitting work

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3177,7 +3177,10 @@ class CompoundModel(Model):
         self._constraints_cache = {}
 
     def _get_left_inputs_from_args(self, args):
-        return args[: self.left.n_inputs]
+        op = self.op
+        if op == "fix_inputs":
+            return [self.right["x"]]
+        return args[: self.right.n_inputs]
 
     def _get_right_inputs_from_args(self, args):
         op = self.op
@@ -3195,6 +3198,9 @@ class CompoundModel(Model):
             # Args expected to look like (*left inputs, *right inputs, *left params, *right params)
             n_inputs = self.left.n_inputs + self.right.n_inputs
             return args[n_inputs : n_inputs + self.n_left_params]
+        elif op == "|":
+            n_inputs = self.right.n_inputs
+            return args[n_inputs : n_inputs + self.n_left_params]
         else:
             return args[self.left.n_inputs : self.left.n_inputs + self.n_left_params]
 
@@ -3205,6 +3211,9 @@ class CompoundModel(Model):
         if op == "&":
             # Args expected to look like (*left inputs, *right inputs, *left params, *right params)
             return args[self.left.n_inputs + self.right.n_inputs + self.n_left_params :]
+        elif op == "|":
+            n_inputs = self.right.n_inputs
+            return args[n_inputs + self.n_left_params :]
         else:
             return args[self.left.n_inputs + self.n_left_params :]
 
@@ -3215,6 +3224,9 @@ class CompoundModel(Model):
         if self.op == "&":
             new_args = list(args[: self.left.n_inputs + self.right.n_inputs])
             args_pos = self.left.n_inputs + self.right.n_inputs
+        elif self.op == "|":
+            args_pos = self.right.n_inputs
+            new_args = list(args[:args_pos])
         else:
             new_args = list(args[: self.left.n_inputs])
             args_pos = self.left.n_inputs


### PR DESCRIPTION
Update some additional methods to make evaluate work, bonus seems to making fitting work too. So the following code runs

```
import numpy as np

from astropy.modeling import fitting
from astropy.modeling.models import fix_inputs
from astropy.modeling.functional_models import Linear1D

xx = np.array([1, 2, 3, 4, 5, 6])

m1 = Linear1D(slope=2, intercept=1)
m2 = Linear1D(slope=4, intercept=2)

comb = m1 | m2
comb_fix = fix_inputs(m1, {'x': xx}) | m2

y1 = comb_fix()
y2 = comb.evaluate(xx, 2, 1, 4, 2)
y3 = comb_fix.evaluate(np.array([0, 0, 0,0]), 2, 1, 4, 2) #the input values shouldn't matter as fixed

assert np.array_equal(y1, y2)
assert np.array_equal(y2, y3)

fitter = fitting.LMLSQFitter()

x_dummy = np.zeros_like(y1)

fitted_p = fitter(comb_fix, x_dummy, y1)
print(fitted_p)
```
